### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/bekk/bekkboard.png?label=ready&title=Ready)](https://waffle.io/bekk/bekkboard)
 # bekkboard
 
 Statistikk og hardware for å holde orden på score for ping pong bord i Trondheim.


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/bekk/bekkboard

This was requested by a real person (user geirsagberg) on waffle.io, we're not trying to spam you.
