### PR TITLE
Adds retry logic to the hardware serial component

### DIFF
--- a/hardware/serial.js
+++ b/hardware/serial.js
@@ -2,29 +2,62 @@ var EventEmitter = require('events').EventEmitter;
 var serialport = require('serialport');
 var SerialPort = serialport.SerialPort;
 
+const MAX_RECONNECT_RETRIES = 15;
+const TIME_LIMIT_IN_MILLISECONDS = 60 * 1000;
+
 module.exports = function (device) {
   var serialPort = new SerialPort(device, {
     parser: serialport.parsers.readline("\n"),
     baudrate: 9600
   }, false);
 
-  var emitter = new EventEmitter();
+  var emitter = new EventEmitter(), isConnected = false;
 
-  serialPort.open(function (error) {
-    if (error) {
-        emitter.emit('disconnect');
-    }
-    else {
-      emitter.emit('connected');
-      serialPort.on('data', function (data) {
-        emitter.emit('data', parseInt(data, 10));
-      });
-
-      serialPort.on('error', function () {
-        emitter.emit('disconnect');
-      });
-    }
+  serialPort.on('data', function (data) {
+    emitter.emit('data', parseInt(data, 10));
   });
 
+  serialPort.on('close', function (data) {
+    isConnected = false;
+    emitter.emit('disconnect');
+    tryReconnectLoop();
+  });
+
+  serialPort.on('open', function (data) {
+    isConnected = true;
+  });
+
+  serialPort.on('error', function () {
+    isConnected = false;
+    emitter.emit('disconnect');
+    tryReconnectLoop();
+  });
+
+  function tryReconnectLoop (connectTime = 100, retries = 0) {
+    if (isConnected) return;
+    if (connectTime >= TIME_LIMIT_IN_MILLISECONDS) {
+      connectTime = TIME_LIMIT_IN_MILLISECONDS;
+    }
+
+    console.log(`Trying to connect to the serialport. Try number: ${retries}`);
+
+    serialPort.open(function (error) {
+      if (!error) {
+        return emitter.emit('connected');
+      }
+      retries++;
+
+      emitter.emit('disconnect');
+
+      if (connectTime < TIME_LIMIT_IN_MILLISECONDS) {
+        connectTime *= 1.5;
+      }
+
+      return setTimeout(() =>
+        tryReconnectLoop(connectTime, retries++), connectTime);
+    });
+  }
+
+  tryReconnectLoop();
   return emitter;
 };


### PR DESCRIPTION
Still a bug where sometimes you don't get the "close" event from serial port if the internal poller isn't running.
